### PR TITLE
Focus invalid element

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Now you can validate the form by calling `validate()` on the [form instance](htt
 $scope.register = function (form) {
     if(form.validate()) {
         // Form is valid!
+    }else{
+       // Focus on invalid element
+       form.focusInvalid();
     }
 }
 ```

--- a/src/angular-validate.js
+++ b/src/angular-validate.js
@@ -26,6 +26,10 @@
                     form.numberOfInvalids = function () {
                         return validator.numberOfInvalids();
                     };
+                    
+                    form.focusInvalid = function(){
+                        return validator.focusInvalid();
+                    }
                 }
             };
         })


### PR DESCRIPTION
The focus method for invalid elements was missing, added to the bridge and update the README with the doc. 
